### PR TITLE
Install target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.sw[op]
 out
 star_fm/star_fm
-
+rtl_biast

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ OUTDIR=$(shell pwd)/out/
 LIBUSB_CFLAGS=$(shell $(PKGCONFIG) libusb-1.0 --cflags)
 LIBUSB_LFLAGS=$(shell $(PKGCONFIG) libusb-1.0 --libs)
 PREFIX := /usr/local
+BINDIR = $(PREFIX)/bin
 SDRD = $(PREFIX)/sdr.d
 RTLDIR = $(SDRD)/starsdr-rtlsdr
 MIRDIR = $(SDRD)/starsdr-mirics
@@ -44,7 +45,7 @@ some: libs rtl_biast
 all: libs star_fm rtl_biast
 
 install:
-	install -Dm755 {.,$(RTLDIR)}/rtl_biast
+	install -Dm755 {.,$(BINDIR)}/rtl_biast
 	install -Dm755 {$(OUTDIR),$(RTLDIR)/}librtlsdr.so
 	install -Dm755 $(OUTDIR)libstarsdr_rtlsdr.so $(RTLDIR)/libstarsdr.so
 	install -Dm755 {$(OUTDIR),$(MIRDIR)/}libmirisdr.so

--- a/Makefile
+++ b/Makefile
@@ -25,16 +25,33 @@
 CC ?=gcc
 CC_PATH=$(shell which $(CC))
 PKGCONFIG=$(shell dirname $(CC_PATH))/pkg-config
-OUTDIR=$(PWD)/out/
+OUTDIR=$(shell pwd)/out/
 LIBUSB_CFLAGS=$(shell $(PKGCONFIG) libusb-1.0 --cflags)
 LIBUSB_LFLAGS=$(shell $(PKGCONFIG) libusb-1.0 --libs)
+PREFIX := /usr/local
+SDRD = $(PREFIX)/sdr.d
+RTLDIR = $(SDRD)/starsdr-rtlsdr
+MIRDIR = $(SDRD)/starsdr-mirics
 
 
-.PHONY: clean clean_all libs all libmirisdr librtlsdr starsdr rtl_fm star_fm outdir release
+.PHONY: clean clean_all libs all libmirisdr librtlsdr starsdr rtl_fm star_fm \
+	outdir release some install uninstall
 
 libs: outdir libmirisdr librtlsdr starsdr
 
+some: libs rtl_biast
+
 all: libs star_fm rtl_biast
+
+install:
+	install -Dm755 {.,$(RTLDIR)}/rtl_biast
+	install -Dm755 {$(OUTDIR),$(RTLDIR)/}librtlsdr.so
+	install -Dm755 $(OUTDIR)libstarsdr_rtlsdr.so $(RTLDIR)/libstarsdr.so
+	install -Dm755 {$(OUTDIR),$(MIRDIR)/}libmirisdr.so
+	install -Dm755 $(OUTDIR)libstarsdr_mirics.so $(MIRDIR)/libstarsdr.so
+
+uninstall:
+	-rm -rf $(SDRD)
 
 clean:
 	rm -rf $(OUTDIR)

--- a/Makefile
+++ b/Makefile
@@ -36,11 +36,11 @@ MIRDIR = $(SDRD)/starsdr-mirics
 
 
 .PHONY: clean clean_all libs all libmirisdr librtlsdr starsdr rtl_fm star_fm \
-	outdir release some install uninstall
+	outdir release installables install uninstall
 
 libs: outdir libmirisdr librtlsdr starsdr
 
-some: libs rtl_biast
+installables: libs rtl_biast
 
 all: libs star_fm rtl_biast
 

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ install:
 
 uninstall:
 	-rm -rf $(SDRD)
+	-rm $(BINDIR)/rtl_biast
 
 clean:
 	rm -rf $(OUTDIR)


### PR DESCRIPTION
This patch adds the install/uninstall and 'some' targets. The install target creates the rxOS-style sdr.d directory under prefix (default: /usr/local). The 'some' target is a shortcut for building the stuff that is usually needed for Outernet receiver setup.

Also adds some paths to the ignore file.